### PR TITLE
visit: let the initializer choose whether save or not.

### DIFF
--- a/app/models/rails_url_shortener/visit.rb
+++ b/app/models/rails_url_shortener/visit.rb
@@ -35,6 +35,7 @@ module RailsUrlShortener
     # Return boolean
     # rubocop:disable Metrics/AbcSize
     def self.parse_and_save(url, request)
+      return false if !RailsUrlShortener.save_visits
       browser(request)
       return false if !RailsUrlShortener.save_bots_visits && @browser.bot?
 

--- a/lib/generators/rails_url_shortener/templates/initializer.rb
+++ b/lib/generators/rails_url_shortener/templates/initializer.rb
@@ -12,3 +12,4 @@ RailsUrlShortener.charset = CHARSETS[:alphanumcase] # used for generate the keys
 RailsUrlShortener.key_length = 6                    # Key length for random generator
 RailsUrlShortener.minimum_key_length = 3            # minimum permited for a key
 RailsUrlShortener.save_bots_visits = false          # if save bots visits
+RailsUrlShortener.save_visits = true                # if save visits

--- a/lib/rails_url_shortener.rb
+++ b/lib/rails_url_shortener.rb
@@ -40,6 +40,8 @@ module RailsUrlShortener
   # so if you put this configuration like false could lose some visits to your link
   # by default saving all requests
   mattr_accessor :save_bots_visits, default: true
+
+  mattr_accessor :save_visits, default: true
 end
 
 ActiveSupport.on_load(:active_record) do

--- a/test/models/rails_url_shortener/visit_test.rb
+++ b/test/models/rails_url_shortener/visit_test.rb
@@ -74,6 +74,26 @@ module RailsUrlShortener
       assert_no_enqueued_jobs do
         assert_not Visit.parse_and_save(rails_url_shortener_urls(:one), request)
       end
+
+      RailsUrlShortener.save_bots_visits = true
+    end
+
+    test "don't save any" do
+      # set the configuration
+      RailsUrlShortener.save_visits = false
+
+      # generate a fake request
+      request = ActionDispatch::TestRequest.create(env = Rack::MockRequest.env_for('/', 'HTTP_HOST' => 'test.host'.b,
+                                                                                        'REMOTE_ADDR' => '1.0.0.0'.b, 'HTTP_USER_AGENT' => 'Rails Testing'.b,
+                                                                                        'HTTP_REFERER' => 'https://example.com'.b))
+      request.user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15'
+
+      # asserts
+      assert_no_enqueued_jobs do
+        assert_not Visit.parse_and_save(rails_url_shortener_urls(:one), request)
+      end
+
+      RailsUrlShortener.save_visits = true
     end
   end
 end


### PR DESCRIPTION
It is useful to disable the visit tracking if not interested. This doesn't create useless data.